### PR TITLE
Fix /etc/hosts for OVN deployments

### DIFF
--- a/18.04/s4lp5.cfg
+++ b/18.04/s4lp5.cfg
@@ -105,7 +105,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp5";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lp6.cfg
+++ b/18.04/s4lp6.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp6";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lp7.cfg
+++ b/18.04/s4lp7.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp7";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lp8.cfg
+++ b/18.04/s4lp8.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp8";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lp9.cfg
+++ b/18.04/s4lp9.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp9";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lpa.cfg
+++ b/18.04/s4lpa.cfg
@@ -105,7 +105,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpa";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lpb.cfg
+++ b/18.04/s4lpb.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpb";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lpc.cfg
+++ b/18.04/s4lpc.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpc";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lpd.cfg
+++ b/18.04/s4lpd.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpd";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/18.04/s4lpe.cfg
+++ b/18.04/s4lpe.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpe";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lp5.cfg
+++ b/20.04/s4lp5.cfg
@@ -105,7 +105,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp5";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lp6.cfg
+++ b/20.04/s4lp6.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp6";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lp7.cfg
+++ b/20.04/s4lp7.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp7";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lp8.cfg
+++ b/20.04/s4lp8.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp8";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lp9.cfg
+++ b/20.04/s4lp9.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lp9";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lpa.cfg
+++ b/20.04/s4lpa.cfg
@@ -105,7 +105,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpa";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lpb.cfg
+++ b/20.04/s4lpb.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpb";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lpc.cfg
+++ b/20.04/s4lpc.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpc";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lpd.cfg
+++ b/20.04/s4lpd.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpd";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\

--- a/20.04/s4lpe.cfg
+++ b/20.04/s4lpe.cfg
@@ -107,7 +107,7 @@ d-i preseed/late_command string \
 HOSTNAME="s4lpe";\
 hostname $HOSTNAME;\
 echo "$HOSTNAME" > /target/etc/hostname;\
-sed -i "/^127.0.0.1/ s/$/ $HOSTNAME/" /target/etc/hosts;\
+sed -i "s/^127.0.0.1\s*/\0$HOSTNAME /" /target/etc/hosts;\
 : ;\
 NIC_ID_1="0.0.c000";\
 NIC_NAME_1="encc000";\


### PR DESCRIPTION
Without this fix, `hostname -f` will print 'localhost'
instead of e.g. 's4lp5', which will then lead to the
ovn-central leader listing the chassis as 'localhost':

```
$ sudo ovn-sbctl show
Chassis localhost
    hostname: localhost
    Encap geneve
        ip: "10.13.3.5"
        options: {csum="true"}
```

This then leads to issues similar to those listed in
lp:1915829.

The solution consists of changing /etc/hosts's first
line
`127.0.0.1       localhost s4lp5`
into
`127.0.0.1       s4lp5 localhost`

Validated on our s390x lab.