### PR TITLE
Do not mount /mnt/ceph

### DIFF
--- a/20.04/s4lp5.cfg
+++ b/20.04/s4lp5.cfg
@@ -239,8 +239,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
 		then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lp6.cfg
+++ b/20.04/s4lp6.cfg
@@ -207,8 +207,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lp7.cfg
+++ b/20.04/s4lp7.cfg
@@ -207,8 +207,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lp8.cfg
+++ b/20.04/s4lp8.cfg
@@ -208,8 +208,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lp9.cfg
+++ b/20.04/s4lp9.cfg
@@ -207,8 +207,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lpa.cfg
+++ b/20.04/s4lpa.cfg
@@ -239,8 +239,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
 		then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lpb.cfg
+++ b/20.04/s4lpb.cfg
@@ -207,8 +207,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lpc.cfg
+++ b/20.04/s4lpc.cfg
@@ -207,8 +207,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lpd.cfg
+++ b/20.04/s4lpd.cfg
@@ -207,8 +207,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \

--- a/20.04/s4lpe.cfg
+++ b/20.04/s4lpe.cfg
@@ -207,8 +207,10 @@ for disk_num in `seq 2 $DISK_COUNT` ;\
         if [ "$DISK_FS" = "true" ] ;\
                 then sleep 30 ;\
                 mkfs.xfs -L $DISK_NAME -f -b size=4096 /dev/disk/by-path/ccw-${DISK_ID}-part1; \
-                in-target mkdir /mnt/${DISK_NAME}; \
-                printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                if [ "$DISK_NAME" != "ceph" ]; then \
+                        in-target mkdir /mnt/${DISK_NAME}; \
+                        printf "LABEL=\"${DISK_NAME}\"\t/mnt/${DISK_NAME}\txfs\tdefaults\t0\t0\n" >> /target/etc/fstab; \
+                fi ;\
         fi ;\
         if [ "$DISK_ADD_LVM" = "true" ] ;\
                 then pvcreate /dev/disk/by-path/ccw-${DISK_ID}-part1; \


### PR DESCRIPTION
In order to pass the underlying `/dev/dasd?1`
partition to ceph-osd via add-disk action, it
needs to be unmounted.